### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the **GitHub Skills** extracurricular activity that was announced by the principal but was missing from the system.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `app.py`
- Activity details:
  - **Description**: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications
  - **Schedule**: Wednesdays, 3:30 PM - 5:00 PM
  - **Max Participants**: 25
  - **Current Participants**: Empty (ready for signups)

## Related Issue
Resolves #6 

## Context
This is time-sensitive as the announcement mentioned registrations would close by the end of this week. Students have been unable to find and register for this activity.